### PR TITLE
feat(storage): organize OHLCV CSV storage by symbol/year/granularity …

### DIFF
--- a/SPEC/spec.md
+++ b/SPEC/spec.md
@@ -9,7 +9,7 @@ Set up a Python-based crypto trading bot called HypeBot that connects to Hyperli
 - **Primary Goal**: Automated crypto trading bot with RSI-based signals and Kelly criterion position sizing
 - **Exchange Integration**: Hyperliquid using custom HTTP client
 - **Data Source**: Configurable data provider (CoinGecko API or Yahoo Finance via yfinance) for price data
-- **Storage**: Local CSV persistence with Pandas
+- **Storage**: Local CSV persistence for historical OHLCV data organized by symbol, year, and granularity
 - **Technical Analysis**: RSI indicator with pandas calculations
 - **Position Management**: Kelly criterion for position sizing
 
@@ -18,11 +18,11 @@ Set up a Python-based crypto trading bot called HypeBot that connects to Hyperli
 2. **As a trader**, I want real-time price data from CoinGecko API so I can make informed trading decisions
 3. **As a trader**, I want RSI signals (long/short) so I can automate trading based on technical analysis
 4. **As a trader**, I want Kelly criterion position sizing so I can optimize risk-adjusted returns
-5. **As a trader**, I want local price data storage so I can analyze historical performance
+5. **As a trader**, I want organized historical OHLCV data storage so I can analyze performance and backtest strategies
 
 ### Acceptance Criteria
 - [ ] Bot successfully connects to Hyperliquid exchange
-- [ ] Price data is retrieved and stored locally via Pandas
+- [ ] Historical OHLCV data is retrieved and stored in organized CSV files by symbol, year, and granularity
 - [ ] RSI indicator calculates and emits buy/sell signals
 - [ ] Kelly criterion calculates optimal position sizes
 - [ ] Bot executes trades based on signals with proper position sizing
@@ -30,6 +30,7 @@ Set up a Python-based crypto trading bot called HypeBot that connects to Hyperli
 - [ ] Error handling and logging are implemented
 - [ ] Data provider is configurable (CoinGecko or Yahoo Finance) without caller code changes
 - [ ] Historical OHLCV retrieval returns standardized DataFrame shape and UTC timestamps
+- [ ] CSV storage supports bidirectional conversion between OHLCVData models and pandas DataFrames
 
 ## 2. Technical Approach
 
@@ -50,7 +51,7 @@ hypebot/
 ### Key Technologies
 - **Exchange**: Custom Hyperliquid HTTP client (httpx)
 - **Price Data**: CoinGecko API (httpx) and Yahoo Finance via `yfinance`
-- **Storage**: Pandas with CSV persistence
+- **Storage**: Organized CSV files with pandas DataFrame conversion for historical OHLCV data
 - **Technical Analysis**: pandas, numpy for RSI calculations
 - **Position Sizing**: Custom Kelly criterion implementation
 - **Configuration**: python-dotenv for environment variables
@@ -120,12 +121,10 @@ MAX_POSITION_SIZE=0.1
 MIN_POSITION_SIZE=0.001
 RISK_FREE_RATE=0.02
 
-# Database Configuration
+# Storage Configuration
 DATA_DIR=data
-PRICE_DATA_FILE=price_data.csv
-POSITIONS_FILE=positions.csv
-TRADES_FILE=trades.csv
-SIGNALS_FILE=signals.csv
+HISTORICAL_DATA_DIR=historical
+CSV_FILE_PREFIX=ohlcv_
 
 # Logging Configuration
 LOG_LEVEL=INFO
@@ -208,7 +207,40 @@ class PositionSize:
     risk_level: Literal["LOW", "MEDIUM", "HIGH"]
 ```
 
-## 5. Module Specifications
+## 5. Storage Specification
+
+### Historical Data Storage
+
+The storage system is designed specifically for historical OHLCV data with the following characteristics:
+
+#### File Organization
+- **Directory Structure**: `{DATA_DIR}/{HISTORICAL_DATA_DIR}/`
+- **File Naming Convention**: `{SYMBOL}_{YEAR}_{GRANULARITY}.csv`
+  - Example: `BTC-USD_2025_1d.csv` for daily BTC-USD price data for 2025
+  - Example: `ETH-USD_2024_1h.csv` for hourly ETH-USD price data for 2024
+- **Granularity Formats**: `1m`, `5m`, `15m`, `30m`, `1h`, `4h`, `1d`, `1w`
+
+#### CSV Format
+CSV files match the OHLCVData model fields exactly:
+```csv
+symbol,timestamp,open,high,low,close,volume,source
+BTC-USD,2025-01-01T00:00:00+00:00,45000.0,45500.0,44800.0,45200.0,1250000.0,coingecko
+BTC-USD,2025-01-01T01:00:00+00:00,45200.0,45300.0,45100.0,45150.0,980000.0,coingecko
+```
+
+#### DataFrame Conversion
+- **From CSV to DataFrame**: Load CSV with UTC timestamp index and OHLCV columns
+- **From DataFrame to CSV**: Save with proper timestamp formatting and field ordering
+- **Metadata Preservation**: Symbol, source, and data type metadata stored in DataFrame.attrs
+- **Timezone Handling**: All timestamps normalized to UTC
+
+#### Storage Operations
+- **Write**: Append new OHLCV data to appropriate CSV file based on symbol, year, granularity
+- **Read**: Load specific symbol/year/granularity combinations into pandas DataFrame
+- **Update**: Handle duplicate records by timestamp (last write wins)
+- **Query**: Support date range filtering and symbol filtering
+
+## 6. Module Specifications
 
 ### Exchange Module (exchange/)
 - **hyperliquid_client.py**: Custom HTTP client for Hyperliquid API with authentication, order placement, position queries
@@ -216,11 +248,10 @@ class PositionSize:
 
 ### Data Module (data/)
 - **client.py**: Provider-agnostic interface and factory for data clients
-- **providers/**:
-  - **coingecko_client.py**: CoinGecko implementation of the data client with rate limiting
-  - **yfinance_client.py**: Yahoo Finance implementation via `yfinance` (thread-wrapped for async API)
-- **storage.py**: CRUD operations for price and market data using Pandas with CSV persistence
-- **models.py**: Price, market, and OHLCV models with serialization methods
+- **coingecko_client.py**: CoinGecko implementation of the data client with rate limiting
+- **yfinance_client.py**: Yahoo Finance implementation via `yfinance` (thread-wrapped for async API)
+- **storage.py**: Historical OHLCV data storage with organized CSV files and DataFrame conversion
+- **models.py**: Price, market, and OHLCV models with CSV serialization and DataFrame conversion methods
 
 ### Indicators Module (indicators/)
 - **rsi_calculator.py**: Calculate RSI using pandas with Wilder's smoothing, generate buy/sell signals with crossover detection
@@ -260,9 +291,12 @@ class PositionSize:
 - **Confidence adjustment**: Signal strength and confidence-based position size adjustments
 
 ### Data Storage Features (data/storage.py)
+- **Organized CSV storage**: Historical OHLCV data stored in files organized by symbol, year, and granularity
+- **File naming convention**: `{SYMBOL}_{YEAR}_{GRANULARITY}.csv` format for easy data management
+- **DataFrame conversion**: Bidirectional conversion between OHLCVData models and pandas DataFrames
 - **Duplicate handling**: Automatic removal of duplicate records based on symbol and timestamp
-- **Data filtering**: Symbol and date range filtering for historical data retrieval
-- **Multiple data types**: Support for price data, market data, positions, trades, and signals
+- **Data filtering**: Symbol, year, granularity, and date range filtering for historical data retrieval
+- **Metadata preservation**: Symbol, source, and data type information preserved in DataFrame.attrs
 
 ### Data Client Features (data/client.py and providers/)
 - **Provider selection**: `DATA_PROVIDER` config selects CoinGecko or Yahoo Finance
@@ -372,7 +406,7 @@ pytest hypebot/tests/
 - Has extensive configuration options through environment variables
 - Includes signal cooldown and risk management features
 - Implements proper position tracking with P&L calculations
-- Uses CSV files for data persistence with Pandas integration
+- Uses organized CSV files for historical OHLCV data persistence with pandas DataFrame conversion
 - Custom Hyperliquid client implementation for better API control
 - Graceful shutdown handling with signal handlers
 - Real-time position price updates

--- a/hypebot/config.py
+++ b/hypebot/config.py
@@ -122,6 +122,8 @@ class DatabaseConfig:
     positions_file: str = "positions.csv"
     trades_file: str = "trades.csv"
     signals_file: str = "signals.csv"
+    historical_data_dir: str = "historical"
+    csv_file_prefix: str = "ohlcv_"
     
     @classmethod
     def from_env(cls) -> "DatabaseConfig":
@@ -131,7 +133,9 @@ class DatabaseConfig:
             price_data_file=os.getenv("PRICE_DATA_FILE", "price_data.csv"),
             positions_file=os.getenv("POSITIONS_FILE", "positions.csv"),
             trades_file=os.getenv("TRADES_FILE", "trades.csv"),
-            signals_file=os.getenv("SIGNALS_FILE", "signals.csv")
+            signals_file=os.getenv("SIGNALS_FILE", "signals.csv"),
+            historical_data_dir=os.getenv("HISTORICAL_DATA_DIR", "historical"),
+            csv_file_prefix=os.getenv("CSV_FILE_PREFIX", "ohlcv_")
         )
 
 

--- a/hypebot/data/storage.py
+++ b/hypebot/data/storage.py
@@ -3,7 +3,7 @@
 import os
 import logging
 from datetime import datetime
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Tuple
 import pandas as pd
 
 from .models import PriceData, MarketData, OHLCVData
@@ -21,6 +21,9 @@ class DataStorage:
         self.config = config
         self.data_dir = config.data_dir
         self._ensure_data_directory()
+        # Historical OHLCV directory
+        self.historical_dir = os.path.join(self.data_dir, getattr(self.config, "historical_data_dir", "historical"))
+        os.makedirs(self.historical_dir, exist_ok=True)
     
     def _ensure_data_directory(self):
         """Ensure data directory exists."""
@@ -312,66 +315,150 @@ class DataStorage:
             logger.error(f"Error getting latest price for {symbol}: {e}")
             return None
     
-    def save_ohlcv_data(self, ohlcv_data: List[OHLCVData], append: bool = True) -> bool:
-        """Save OHLCV data to CSV file."""
+    def _historical_filename(self, symbol: str, year: int, granularity: str) -> str:
+        symbol_upper = symbol.upper()
+        return f"{symbol_upper}_{year}_{granularity}.csv"
+
+    def _historical_filepath(self, symbol: str, year: int, granularity: str) -> str:
+        return os.path.join(self.historical_dir, self._historical_filename(symbol, year, granularity))
+
+    def _normalize_timestamp_series_utc(self, ts: pd.Series) -> pd.Series:
+        s = pd.to_datetime(ts, utc=True)
+        return s
+
+    def _write_ohlcv_df(self, df: pd.DataFrame, filepath: str, append: bool) -> None:
+        # Ensure column order per spec
+        columns = ["symbol", "timestamp", "open", "high", "low", "close", "volume", "source"]
+        # Drop unknown columns
+        df = df[[c for c in columns if c in df.columns]]
+        # Remove duplicates by symbol+timestamp (last write wins)
+        df = df.drop_duplicates(subset=["symbol", "timestamp"], keep="last")
+        # If appending, merge with existing
+        if append and os.path.exists(filepath):
+            existing = pd.read_csv(filepath)
+            if not existing.empty:
+                existing["timestamp"] = pd.to_datetime(existing["timestamp"], utc=True)
+            combined = pd.concat([existing, df], ignore_index=True)
+            combined = combined.drop_duplicates(subset=["symbol", "timestamp"], keep="last")
+            # Sort by timestamp
+            combined = combined.sort_values("timestamp")
+            # Write
+            combined.to_csv(filepath, index=False)
+        else:
+            df = df.sort_values("timestamp")
+            df.to_csv(filepath, index=False)
+
+    def save_ohlcv_data(self, ohlcv_data: List[OHLCVData], granularity: str, append: bool = True) -> bool:
+        """Save OHLCV data to organized CSV files by symbol/year/granularity."""
         try:
             if not ohlcv_data:
                 return True
-            
+
             # Convert to DataFrame
             df = pd.DataFrame([data.to_dict() for data in ohlcv_data])
-            
-            file_path = self._get_file_path("ohlcv_data.csv")
-            
-            if append and os.path.exists(file_path):
-                # Load existing data and append
-                existing_df = pd.read_csv(file_path)
-                existing_df['timestamp'] = pd.to_datetime(existing_df['timestamp'])
-                combined_df = pd.concat([existing_df, df], ignore_index=True)
-                # Remove duplicates based on symbol and timestamp
-                combined_df = combined_df.drop_duplicates(subset=['symbol', 'timestamp'], keep='last')
-                combined_df.to_csv(file_path, index=False)
-            else:
-                df.to_csv(file_path, index=False)
-            
-            logger.info(f"Saved {len(ohlcv_data)} OHLCV data records")
+            if df.empty:
+                return True
+            # Normalize timestamps to UTC
+            df["timestamp"] = self._normalize_timestamp_series_utc(df["timestamp"])
+
+            # Group by symbol and year, write to corresponding files
+            records_written = 0
+            for (symbol, year), group in df.groupby(["symbol", df["timestamp"].dt.year]):
+                filepath = self._historical_filepath(symbol, int(year), granularity)
+                self._write_ohlcv_df(group, filepath, append=append)
+                records_written += len(group)
+
+            logger.info(f"Saved {records_written} OHLCV data records to historical storage for granularity {granularity}")
             return True
             
         except Exception as e:
             logger.error(f"Error saving OHLCV data: {e}")
             return False
     
+    def _list_symbol_year_files(self, symbol: str, granularity: str, year: Optional[int] = None) -> List[str]:
+        symbol_upper = symbol.upper()
+        files: List[str] = []
+        if year is not None:
+            candidate = self._historical_filepath(symbol_upper, int(year), granularity)
+            if os.path.exists(candidate):
+                files.append(candidate)
+            return files
+        # scan directory for matching files
+        try:
+            for fname in os.listdir(self.historical_dir):
+                if not fname.endswith(".csv"):
+                    continue
+                # Expected: SYMBOL_YEAR_GRANULARITY.csv
+                parts = fname[:-4].split("_")
+                if len(parts) != 3:
+                    continue
+                f_symbol, f_year, f_gran = parts
+                if f_symbol == symbol_upper and f_gran == granularity:
+                    files.append(os.path.join(self.historical_dir, fname))
+        except FileNotFoundError:
+            pass
+        return sorted(files)
+
     def load_ohlcv_data(
-        self, 
-        symbol: Optional[str] = None, 
+        self,
+        symbol: Optional[str] = None,
+        granularity: Optional[str] = None,
+        year: Optional[int] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None
     ) -> pd.DataFrame:
-        """Load OHLCV data from CSV file."""
+        """Load OHLCV data from organized CSV files.
+
+        If symbol and granularity are provided, loads corresponding files (optionally filtered by year).
+        If symbol is None, loads all symbols for the provided granularity.
+        """
         try:
-            file_path = self._get_file_path("ohlcv_data.csv")
-            
-            if not os.path.exists(file_path):
-                logger.warning(f"OHLCV data file not found: {file_path}")
+            frames: List[pd.DataFrame] = []
+            # Determine files to load
+            if symbol and granularity:
+                files = self._list_symbol_year_files(symbol, granularity, year)
+            else:
+                # load all files optionally filtered by granularity
+                files = []
+                try:
+                    for fname in os.listdir(self.historical_dir):
+                        if not fname.endswith('.csv'):
+                            continue
+                        if granularity:
+                            if not fname.endswith(f"_{granularity}.csv"):
+                                continue
+                        files.append(os.path.join(self.historical_dir, fname))
+                except FileNotFoundError:
+                    files = []
+
+            if not files:
+                logger.warning("No OHLCV historical files found for criteria")
                 return pd.DataFrame()
-            
-            df = pd.read_csv(file_path)
-            df['timestamp'] = pd.to_datetime(df['timestamp'])
-            
+
+            for path in files:
+                tmp = pd.read_csv(path)
+                if tmp.empty:
+                    continue
+                tmp['timestamp'] = pd.to_datetime(tmp['timestamp'], utc=True)
+                frames.append(tmp)
+
+            if not frames:
+                return pd.DataFrame()
+
+            df = pd.concat(frames, ignore_index=True)
             # Filter by symbol if provided
             if symbol:
                 df = df[df['symbol'] == symbol.upper()]
-            
             # Filter by date range if provided
-            if start_date:
-                df = df[df['timestamp'] >= start_date]
-            if end_date:
-                df = df[df['timestamp'] <= end_date]
-            
+            if start_date is not None:
+                df = df[df['timestamp'] >= pd.to_datetime(start_date, utc=True)]
+            if end_date is not None:
+                df = df[df['timestamp'] <= pd.to_datetime(end_date, utc=True)]
+
             # Sort by timestamp
             df = df.sort_values('timestamp')
-            
-            logger.info(f"Loaded {len(df)} OHLCV data records")
+
+            logger.info(f"Loaded {len(df)} OHLCV data records from historical storage")
             return df
             
         except Exception as e:
@@ -381,13 +468,14 @@ class DataStorage:
     def get_historical_ohlcv_data(
         self, 
         symbol: str,
+        granularity: str,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None
     ) -> pd.DataFrame:
         """Get historical OHLCV data with standardized DataFrame shape and UTC timestamps."""
         try:
             # Load OHLCV data
-            df = self.load_ohlcv_data(symbol=symbol, start_date=start_date, end_date=end_date)
+            df = self.load_ohlcv_data(symbol=symbol, granularity=granularity, start_date=start_date, end_date=end_date)
             
             if df.empty:
                 logger.warning(f"No OHLCV data found for symbol {symbol}")
@@ -420,10 +508,11 @@ class DataStorage:
                 "data_type": "ohlcv",
                 "total_records": len(ohlcv_df),
                 "start_date": ohlcv_df.index.min() if not ohlcv_df.empty else None,
-                "end_date": ohlcv_df.index.max() if not ohlcv_df.empty else None
+                "end_date": ohlcv_df.index.max() if not ohlcv_df.empty else None,
+                "granularity": granularity
             }
             
-            logger.info(f"Retrieved {len(ohlcv_df)} historical OHLCV records for {symbol}")
+            logger.info(f"Retrieved {len(ohlcv_df)} historical OHLCV records for {symbol} at {granularity}")
             return ohlcv_df
             
         except Exception as e:
@@ -433,6 +522,7 @@ class DataStorage:
     def get_latest_ohlcv_data(self, symbol: str) -> Optional[OHLCVData]:
         """Get the latest OHLCV data for a symbol."""
         try:
+            # Load across all granularities and pick latest overall
             df = self.load_ohlcv_data(symbol=symbol)
             if df.empty:
                 return None

--- a/hypebot/tests/test_data_storage.py
+++ b/hypebot/tests/test_data_storage.py
@@ -271,7 +271,7 @@ class TestDataStorage:
         ]
         
         # Save data
-        success = self.storage.save_ohlcv_data(ohlcv_data)
+        success = self.storage.save_ohlcv_data(ohlcv_data, granularity="1d")
         assert success
         
         # Load data
@@ -289,10 +289,10 @@ class TestDataStorage:
             OHLCVData("ETH", datetime.utcnow(), 2900.0, 3100.0, 2850.0, 3000.0, 500000.0)
         ]
         
-        self.storage.save_ohlcv_data(ohlcv_data)
+        self.storage.save_ohlcv_data(ohlcv_data, granularity="1h")
         
         # Load only BTC data
-        btc_data = self.storage.load_ohlcv_data(symbol="BTC")
+        btc_data = self.storage.load_ohlcv_data(symbol="BTC", granularity="1h")
         assert len(btc_data) == 1
         assert btc_data.iloc[0]["symbol"] == "BTC"
         assert btc_data.iloc[0]["open"] == 49000.0
@@ -307,10 +307,11 @@ class TestDataStorage:
             OHLCVData("BTC", now, 50000.0, 52000.0, 49500.0, 51000.0, 1100000.0)
         ]
         
-        self.storage.save_ohlcv_data(ohlcv_data)
+        self.storage.save_ohlcv_data(ohlcv_data, granularity="1d")
         
         # Load data from last day only
         recent_data = self.storage.load_ohlcv_data(
+            granularity="1d",
             start_date=now - timedelta(days=1)
         )
         assert len(recent_data) == 2
@@ -325,10 +326,10 @@ class TestDataStorage:
             OHLCVData("BTC", now, 50000.0, 51000.0, 49500.0, 50500.0, 1200000.0)
         ]
         
-        self.storage.save_ohlcv_data(ohlcv_data)
+        self.storage.save_ohlcv_data(ohlcv_data, granularity="1h")
         
         # Get historical data
-        historical_df = self.storage.get_historical_ohlcv_data("BTC")
+        historical_df = self.storage.get_historical_ohlcv_data("BTC", "1h")
         
         # Check DataFrame structure
         assert not historical_df.empty
@@ -343,6 +344,7 @@ class TestDataStorage:
         assert historical_df.attrs["symbol"] == "BTC"
         assert historical_df.attrs["data_type"] == "ohlcv"
         assert historical_df.attrs["total_records"] == 3
+        assert historical_df.attrs["granularity"] == "1h"
     
     def test_get_historical_ohlcv_data_with_date_range(self):
         """Test getting historical OHLCV data with date range filtering."""
@@ -355,11 +357,12 @@ class TestDataStorage:
             OHLCVData("BTC", now, 49500.0, 50500.0, 49000.0, 50000.0, 1050000.0)
         ]
         
-        self.storage.save_ohlcv_data(ohlcv_data)
+        self.storage.save_ohlcv_data(ohlcv_data, granularity="1d")
         
         # Get data from last 2 days only (excluding today)
         historical_df = self.storage.get_historical_ohlcv_data(
-            "BTC", 
+            "BTC",
+            "1d",
             start_date=now - timedelta(days=2),
             end_date=now - timedelta(days=1)
         )
@@ -369,7 +372,7 @@ class TestDataStorage:
     
     def test_get_historical_ohlcv_data_no_data(self):
         """Test getting historical OHLCV data when no data exists."""
-        historical_df = self.storage.get_historical_ohlcv_data("NONEXISTENT")
+        historical_df = self.storage.get_historical_ohlcv_data("NONEXISTENT", "1h")
         
         assert historical_df.empty
         assert list(historical_df.columns) == ["open", "high", "low", "close", "volume"]
@@ -384,7 +387,7 @@ class TestDataStorage:
             OHLCVData("BTC", now, 50000.0, 51000.0, 49500.0, 50500.0, 1200000.0)
         ]
         
-        self.storage.save_ohlcv_data(ohlcv_data)
+        self.storage.save_ohlcv_data(ohlcv_data, granularity="1h")
         
         # Get latest OHLCV data
         latest = self.storage.get_latest_ohlcv_data("BTC")
@@ -404,13 +407,13 @@ class TestDataStorage:
         ohlcv_data_1 = [
             OHLCVData("BTC", datetime.utcnow(), 49000.0, 50000.0, 48500.0, 49500.0, 1000000.0)
         ]
-        self.storage.save_ohlcv_data(ohlcv_data_1)
+        self.storage.save_ohlcv_data(ohlcv_data_1, granularity="1d")
         
         # Save additional data
         ohlcv_data_2 = [
             OHLCVData("ETH", datetime.utcnow(), 2900.0, 3000.0, 2850.0, 2950.0, 500000.0)
         ]
-        self.storage.save_ohlcv_data(ohlcv_data_2)
+        self.storage.save_ohlcv_data(ohlcv_data_2, granularity="1d")
         
         # Load all data
         all_data = self.storage.load_ohlcv_data()
@@ -472,12 +475,29 @@ class TestDataStorage:
         ]
         
         # Save first batch
-        self.storage.save_ohlcv_data(ohlcv_data_1)
+        self.storage.save_ohlcv_data(ohlcv_data_1, granularity="1h")
         
         # Save second batch (should replace duplicate)
-        self.storage.save_ohlcv_data(ohlcv_data_2)
+        self.storage.save_ohlcv_data(ohlcv_data_2, granularity="1h")
         
         # Load data - should only have one record with updated values
-        loaded_data = self.storage.load_ohlcv_data(symbol="BTC")
+        loaded_data = self.storage.load_ohlcv_data(symbol="BTC", granularity="1h")
         assert len(loaded_data) == 1
         assert loaded_data.iloc[0]["close"] == 50000.0  # Should be the second value
+
+    def test_historical_file_naming_and_directory(self):
+        """Test that files are created under historical dir with correct names."""
+        now = datetime.utcnow()
+        ohlcv_data = [
+            OHLCVData("BTC-USD", now, 45000.0, 45500.0, 44800.0, 45200.0, 1250000.0, source="coingecko")
+        ]
+        granularity = "1d"
+        assert self.storage.save_ohlcv_data(ohlcv_data, granularity=granularity)
+        year = now.year
+        hist_dir = os.path.join(self.config.data_dir, getattr(self.config, "historical_data_dir", "historical"))
+        expected_filename = f"BTC-USD_{year}_{granularity}.csv"
+        expected_path = os.path.join(hist_dir, expected_filename)
+        assert os.path.exists(expected_path)
+        # Verify CSV header columns order
+        df = pd.read_csv(expected_path)
+        assert list(df.columns)[:7] == ["symbol", "timestamp", "open", "high", "low", "close", "volume"]


### PR DESCRIPTION
…per spec

- Add historical storage layout: {DATA_DIR}/{HISTORICAL_DATA_DIR}/ with files named {SYMBOL}_{YEAR}_{GRANULARITY}.csv
- Normalize timestamps to UTC; enforce CSV columns: symbol,timestamp,open,high,low,close,volume,source
- Handle duplicates by (symbol,timestamp) with last-write-wins
- Preserve DataFrame attrs metadata (symbol, source, data_type, total_records, start_date, end_date, granularity)
- Extend DataStorage APIs to accept granularity and query by date range/year
- Update DatabaseConfig: add HISTORICAL_DATA_DIR and CSV_FILE_PREFIX env support
- Update tests to assert new layout, metadata, and duplicate handling

Spec alignment: SPEC/spec.md §5 (Storage Specification), §293–300 (Data Storage Features)

BREAKING CHANGE:
- save_ohlcv_data now requires granularity
- get_historical_ohlcv_data requires granularity
- load_ohlcv_data accepts granularity/year parameters