### PR TITLE
feat(strategy): add RSI+EMA Hybrid strategy and EMA indicator; update…

### DIFF
--- a/SPEC/spec.md
+++ b/SPEC/spec.md
@@ -48,6 +48,7 @@ hypebot/
 - **rsi_calculator.py**: RSI calculation with signal generation
 - **base_indicator.py**: Abstract base class for indicators
 - **models.py**: Indicator and signal models
+- **ema (planned/added)**: EMA calculation used by hybrid strategies
 
 ### Position Module (`position/`)
 - **manager.py**: Portfolio tracking and P&L calculation
@@ -63,6 +64,7 @@ hypebot/
 - **runner.py**: Strategy execution runner
 - **client.py**: Trading client interface
 - **rsi_strategy.py**: RSI-based trading strategy
+- **hybrid_rsi_ema (spec)**: Trend-filtered RSI+EMA hybrid strategy (all-in/all-out)
 - **models.py**: Strategy-specific models
 
 ### Backtesting Module (`backtesting/`)
@@ -128,7 +130,7 @@ pytest-asyncio>=0.21.0
 - **TradingSignal**: RSI-based buy/sell signals with strength and metadata
 - **Position**: Portfolio position with P&L tracking
 - **StrategyOrder**: Position-sized orders from strategies
-- **BacktestResult**: Comprehensive backtesting results with metrics
+- **BacktestResult**: Comprehensive backtesting results with metrics and position history
 
 ### Storage Format
 
@@ -136,6 +138,29 @@ Historical data is stored in organized CSV files:
 - **File naming**: `{SYMBOL}_{YEAR}_{GRANULARITY}.csv`
 - **Example**: `BTC-USD_2025_1d.csv`
 - **Format**: Standardized OHLCV columns with UTC timestamps
+
+### Position Data Format
+
+Position tracking data is exported as CSV files with the following structure:
+- **File naming**: `positions_{strategy_name}.csv`
+- **Example**: `positions_RSIStrategy.csv`
+- **Format**: One row per tick, containing:
+  - `timestamp`: UTC timestamp of the tick
+  - `symbol`: Asset symbol (e.g., "SOL-USD")
+  - `side`: Position side ("LONG" or "SHORT")
+  - `size`: Position size in units
+  - `entry_price`: Price at which position was opened
+  - `current_price`: Current market price at this tick
+  - `pnl`: Total P&L (realized + unrealized)
+  - `realized_pnl`: P&L from closed portions
+  - `unrealized_pnl`: P&L from open position
+  - `pnl_percentage`: P&L as percentage of entry value
+  - `kelly_size`: Kelly criterion recommended size
+  - `market_value`: Current market value (size × current_price)
+  - `entry_value`: Entry value (size × entry_price)
+  - `position_timestamp`: When position was originally opened
+  - `cash_balance`: Current cash balance
+- **Empty rows**: When no positions are held, only timestamp and cash_balance are populated
 
 ## Strategy System
 
@@ -159,10 +184,9 @@ The `StrategyRunner` orchestrates strategy execution:
 
 All implemented trading strategies are documented in [strategies.md](strategies.md).
 
-The default RSI strategy provides:
-- RSI-based signal generation with configurable thresholds
-- Kelly Criterion position sizing
-- Risk management and signal filtering
+Included strategies:
+- RSI Strategy: RSI-based momentum with Kelly position sizing
+- RSI + EMA Hybrid: Trend-filtered momentum using RSI(14) and EMA(20), all-in entries and full exits per rules
 
 ## Backtesting
 
@@ -174,12 +198,34 @@ The `BackTester` class provides:
 - Comprehensive performance metrics
 - Equity curve visualization
 - Buy-and-hold baseline comparison
+- Detailed position tracking with CSV export per tick
 
 #### Equity Calculation
 - Equity at each tick is the sum of:
   - Mark-to-market value of all open asset positions, and
   - Current cash position balance
 - The backtester records this equity on every step to produce the equity curve.
+
+#### Position Tracking
+- The backtester captures detailed position data for each strategy at every tick
+- Position data includes all available information from the position manager:
+  - Symbol, side (LONG/SHORT), size, entry price, current price
+  - P&L (total, realized, unrealized), P&L percentage
+  - Kelly size, market value, entry value
+  - Timestamp of position creation and last update
+  - Current cash balance
+- This position data is exported as CSV files with one row per tick per strategy
+- File naming: `positions_{strategy_name}.csv`
+- Enables detailed analysis of position evolution throughout the backtest period
+
+### Backtest Output Files
+
+The backtesting system generates the following files for each strategy:
+- **Equity Curve**: `equity_{strategy_name}.csv` - Portfolio value over time
+- **Position History**: `positions_{strategy_name}.csv` - Detailed position data per tick
+- **Trade Log**: `trades_{strategy_name}.csv` - Individual trade executions
+- **Performance Metrics**: `metrics_{strategy_name}.json` - Calculated performance statistics
+- **Visualization**: `equity_{strategy_name}.png` - Equity curve plot
 
 #### Validity of trading strategy orders
 - If the strategy being backtested issues orders that are incompatible with their overall portfolio positions (e.g. opening asset positions without sufficient cash, closing asset positions without sufficient asset sizes), such actions are marked as errors and the backtesting stopped immediately

--- a/SPEC/strategies.md
+++ b/SPEC/strategies.md
@@ -122,3 +122,73 @@ The RSI strategy is implemented in `hypebot/strategy/rsi_strategy.py` and follow
 The RSI strategy can be backtested using the HypeBot backtesting engine. See the main [specification](spec.md) for details on running backtests and analyzing performance metrics.
 
 Both strategies’ equity outcomes reflect: mark-to-market value of open asset positions plus remaining cash in the portfolio at each step, as recorded by the backtester’s equity curve.
+
+## RSI + EMA Hybrid Strategy (Trend-Filtered Momentum)
+
+A hybrid, momentum-with-trend filter strategy combining RSI with the 20-period Exponential Moving Average (EMA).
+
+### Overview
+
+The RSI + EMA Hybrid strategy seeks long entries only when momentum aligns with an established uptrend. It uses RSI to gauge momentum and a 20-period EMA as a trend filter and support confirmation. Position sizing for this strategy is all-in/all-out per signal as specified below.
+
+### Strategy Parameters
+
+```env
+# RSI + EMA Hybrid Configuration
+RSI_PERIOD=14            # RSI lookback for momentum
+RSI_OVERSOLD=30          # Oversold threshold used for cross-out detection
+RSI_TREND_THRESHOLD=50   # Momentum confirmation threshold for long bias
+EMA_PERIOD=20            # EMA lookback for trend filter
+```
+
+Notes:
+- The strategy ignores Kelly-based sizing and instead uses full available cash on entries and fully exits on sells.
+- Thresholds may be overridden per backtest via strategy parameters.
+
+### Signal Generation
+
+Long-only strategy. A strong LONG signal is triggered when BOTH conditions are true on the current bar:
+- RSI momentum confirmation:
+  - RSI(14) > 50; OR
+  - RSI crosses up from below the oversold threshold (default: 30) this bar
+- Trend filter and support confirmation:
+  - Close price > EMA(20)
+
+Exit (close the long) when ANY of the following occurs:
+- RSI falls below 50; OR
+- Close price < EMA(20)
+
+### Order Sizing and Execution
+
+- On a buy signal, the strategy places a market buy using the entire available cash balance for the asset (subject to commission and lot constraints).
+- On an exit signal, the strategy closes the entire position in the asset.
+- No pyramiding or partial scaling is performed.
+- Only one position per asset is maintained at a time.
+
+### Risk Management and Filters
+
+- Trend filter via EMA(20) is required for entries and acts as a trailing support for exits.
+- No stop-loss or take-profit is enforced by this spec; exits occur per RSI/EMA rules above.
+- No Kelly Criterion sizing is applied in this strategy by design.
+
+### Multi-Asset Behavior
+
+- For multiple assets, signals are evaluated independently per asset.
+- Each asset uses its own available cash derived from the global cash balance; purchases use all currently available cash (i.e., the full remaining cash at the time of signal). There is no enforced equal-weighting rebalance.
+
+### Implementation
+
+The strategy should implement the standard `Strategy` interface with:
+- `assets`: List of symbols to trade
+- `interval`: Data granularity
+- `tick()`: Generates orders per above rules (all-in buy or full exit)
+- `on_start()/on_stop()`: Lifecycle hooks
+
+Indicator computations required:
+- RSI with configurable period (default 14)
+- EMA with configurable period (default 20)
+
+### Backtesting
+
+- Evaluate against Buy-and-Hold as comparator.
+- Key performance metrics include hit rate, average trade return, maximum drawdown, and time in market—often lower than simple RSI due to trend filter.

--- a/SPEC/utilities.md
+++ b/SPEC/utilities.md
@@ -99,6 +99,7 @@ python backtest.py [OPTIONS] [--config CONFIG_FILE]
 - **--strategy, -s** (required): Strategy name to use for backtesting
   - Valid values: "rsi", "buy_and_hold" (extensible for future strategies)
   - Note: Buy-and-hold control strategy is automatically included in all backtests
+  - Planned/added: "rsi_ema_hybrid" for trend-filtered momentum
 - **--interval, -i** (optional): Data granularity/interval (default: "1d")
   - Valid values: "1h", "4h", "1d", "1w", "1mo"
 - **--start-date, --start** (optional): Start date for backtest (default: earliest available data)
@@ -141,6 +142,11 @@ strategy_params:
     overbought: 70
   buy_and_hold:
     # No parameters required - uses equal distribution across assets
+  rsi_ema_hybrid:
+    rsi_period: 14
+    rsi_oversold: 30
+    rsi_trend_threshold: 50
+    ema_period: 20
 ```
 
 ### Usage Examples

--- a/backtest.py
+++ b/backtest.py
@@ -27,7 +27,9 @@ from hypebot.backtesting.backtester import BackTester, CommissionModel
 from hypebot.backtesting.metrics import compute_metrics
 from hypebot.backtesting.visualize import plot_equity_curves
 from hypebot.indicators.rsi_calculator import RSICalculator
+from hypebot.indicators.ema import EMACalculator
 from hypebot.strategy.rsi_strategy import RSIStrategy
+from hypebot.strategy.hybrid_rsi_ema_strategy import RSIEMAHybridStrategy
 from hypebot.strategy.buy_and_hold_strategy import BuyAndHoldStrategy
 from hypebot.data.storage import DataStorage
 from hypebot.position.manager import PositionManager
@@ -139,6 +141,30 @@ def _build_strategy(name: str, config: Config, params: Dict, assets: list[str], 
             assets=assets,
             interval=interval,
             position_manager=pm
+        )
+    elif key in ("rsi_ema_hybrid", "hybrid", "rsiema"):
+        # Parameters with defaults from spec
+        rsi_period = int(params.get("rsi_period", config.trading.rsi_period))
+        rsi_oversold = float(params.get("rsi_oversold", config.trading.rsi_oversold))
+        rsi_trend_threshold = float(params.get("rsi_trend_threshold", 50.0))
+        ema_period = int(params.get("ema_period", 20))
+
+        rsi_calc = RSICalculator(
+            period=rsi_period,
+            oversold_threshold=rsi_oversold,
+            overbought_threshold=config.trading.rsi_overbought,
+        )
+        ema_calc = EMACalculator(period=ema_period)
+        storage = DataStorage(config.database)
+        pm = PositionManager(config.trading, storage, load_existing=False)
+        return RSIEMAHybridStrategy(
+            assets=assets,
+            interval=interval,
+            position_manager=pm,
+            rsi_calculator=rsi_calc,
+            ema_calculator=ema_calc,
+            rsi_trend_threshold=rsi_trend_threshold,
+            oversold_threshold=rsi_oversold,
         )
     raise ValueError(f"Unsupported strategy: {name}")
 
@@ -285,6 +311,29 @@ def main(argv: Optional[list[str]] = None) -> int:
     except Exception as e:
         print(f"Warning: failed to write trades CSV: {e}")
 
+    # 4) Positions CSV (capture position data for each tick)
+    positions_csv_path = os.path.join(output_dir, f"positions_{strategy_name.replace(' ', '_')}.csv")
+    try:
+        if hasattr(result, "positions") and isinstance(result.positions, pd.DataFrame) and not result.positions.empty:  # type: ignore
+            # Reset index to include timestamp as a column
+            positions_df = result.positions.reset_index()  # type: ignore
+            # Ensure timestamp column exists and is properly formatted
+            if "timestamp" in positions_df.columns:
+                positions_df["timestamp"] = pd.to_datetime(positions_df["timestamp"])
+            positions_df.to_csv(positions_csv_path, index=False)
+            print(f"Saved positions CSV: {positions_csv_path}")
+        else:
+            # Create empty CSV with proper headers
+            empty_positions = pd.DataFrame(columns=[
+                "timestamp", "symbol", "side", "size", "entry_price", "current_price",
+                "pnl", "realized_pnl", "unrealized_pnl", "pnl_percentage", "kelly_size",
+                "market_value", "entry_value", "position_timestamp", "cash_balance"
+            ])
+            empty_positions.to_csv(positions_csv_path, index=False)
+            print(f"Saved empty positions CSV: {positions_csv_path}")
+    except Exception as e:
+        print(f"Warning: failed to write positions CSV: {e}")
+
     # Plot will be generated in the buy-and-hold section if available
 
     # 5) Debug info
@@ -345,6 +394,30 @@ def main(argv: Optional[list[str]] = None) -> int:
                     print(f"Saved buy-and-hold trades CSV: {control_trades_csv_path}")
         except Exception as e:
             print(f"Warning: failed to write buy-and-hold trades CSV: {e}")
+        
+        # Save buy-and-hold positions CSV
+        control_positions_csv_path = os.path.join(output_dir, "positions_buy_and_hold.csv")
+        try:
+            if hasattr(control_result, "positions") and isinstance(control_result.positions, pd.DataFrame) and not control_result.positions.empty:
+                # Reset index to include timestamp as a column
+                positions_df = control_result.positions.reset_index()
+                # Ensure timestamp column exists and is properly formatted
+                if "timestamp" in positions_df.columns:
+                    positions_df["timestamp"] = pd.to_datetime(positions_df["timestamp"])
+                positions_df.to_csv(control_positions_csv_path, index=False)
+                print(f"Saved buy-and-hold positions CSV: {control_positions_csv_path}")
+            else:
+                # Create empty CSV with proper headers
+                empty_positions = pd.DataFrame(columns=[
+                    "timestamp", "symbol", "side", "size", "entry_price", "current_price",
+                    "pnl", "realized_pnl", "unrealized_pnl", "pnl_percentage", "kelly_size",
+                    "market_value", "entry_value", "position_timestamp", "cash_balance"
+                ])
+                empty_positions.to_csv(control_positions_csv_path, index=False)
+                print(f"Saved empty buy-and-hold positions CSV: {control_positions_csv_path}")
+        except Exception as e:
+            print(f"Warning: failed to write buy-and-hold positions CSV: {e}")
+        
         print(f"Saved buy-and-hold equity CSV: {control_ecsv_path}")
         print(f"Saved buy-and-hold metrics JSON: {control_mjson_path}")
     

--- a/hypebot/backtesting/backtester.py
+++ b/hypebot/backtesting/backtester.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Tuple, Any
 
 import numpy as np
 import pandas as pd
@@ -32,6 +32,7 @@ class BacktestResult:
     orders: List[Order]
     trades: List[Dict[str, float]]
     snapshots: pd.DataFrame
+    positions: pd.DataFrame  # Position data for each tick
     errors: List[str]
 
 
@@ -145,6 +146,7 @@ class BackTester:
                 orders=[],
                 trades=[],
                 snapshots=pd.DataFrame(),
+                positions=pd.DataFrame(),
                 errors=[],
             )
         all_index = frames[0].index
@@ -156,10 +158,65 @@ class BackTester:
         # Cash/equity tracking (simplified: track portfolio as sum of position values; here, we emulate by marking to close)
         equity_points: List[Tuple[datetime, float]] = []
         snapshots: List[Dict[str, float]] = []
+        position_snapshots: List[Dict[str, Any]] = []
 
         errors: List[str] = []
+        # Define a per-tick callback to snapshot cash/positions after each tick execution
+        position_snapshots: List[Dict[str, Any]] = []
+        snapshots: List[Dict[str, float]] = []
+
+        def _after_tick(as_of: datetime) -> None:
+            total_value = pm.cash_balance
+            tick_position_data: Dict[str, Any] = {
+                "timestamp": as_of,
+                "symbol": None,
+                "side": None,
+                "size": None,
+                "entry_price": None,
+                "current_price": None,
+                "pnl": None,
+                "realized_pnl": None,
+                "unrealized_pnl": None,
+                "pnl_percentage": None,
+                "kelly_size": None,
+                "market_value": None,
+                "entry_value": None,
+                "position_timestamp": None,
+                "cash_balance": pm.cash_balance,
+            }
+
+            for a in assets:
+                df = preloaded.get(a)
+                if df is not None and not df.empty:
+                    sub = df[df.index <= pd.to_datetime(as_of, utc=True)]
+                    if not sub.empty:
+                        price = float(sub["close"].iloc[-1])
+                        pos = pm.get_position(a)
+                        if pos is not None:
+                            pm.update_position_price(a, price)
+                            total_value += pos.size * price
+                            tick_position_data.update({
+                                "symbol": pos.symbol,
+                                "side": pos.side,
+                                "size": pos.size,
+                                "entry_price": pos.entry_price,
+                                "current_price": pos.current_price,
+                                "pnl": pos.pnl,
+                                "realized_pnl": pos.realized_pnl,
+                                "unrealized_pnl": pos.unrealized_pnl,
+                                "pnl_percentage": pos.pnl_percentage,
+                                "kelly_size": pos.kelly_size,
+                                "market_value": pos.market_value,
+                                "entry_value": pos.entry_value,
+                                "position_timestamp": pos.timestamp,
+                            })
+
+            equity_points.append((as_of, total_value))
+            snapshots.append({"timestamp": as_of, "equity": total_value})
+            position_snapshots.append(tick_position_data)
+
         try:
-            orders = await runner.run(ticks)
+            orders = await runner.run(ticks, on_after_tick=_after_tick)
         except RuntimeError as e:
             # Illegal order encountered; stop immediately and report error
             # Preserve any orders placed before the error
@@ -172,36 +229,43 @@ class BackTester:
         # expose simple profiling info on the result via snapshots attrs
         profile_info = getattr(runner, "profile", {})
 
-        # Build equity curve by marking to last close per asset and summing cash plus market value
-        # Calculate total portfolio value at each tick
-        for t in ticks:
-            total_value = pm.cash_balance
-            for a in assets:
-                df = preloaded.get(a)
-                if df is not None and not df.empty:
-                    # locate last price at or before t
-                    sub = df[df.index <= pd.to_datetime(t, utc=True)]
-                    if not sub.empty:
-                        price = float(sub["close"].iloc[-1])
-                        pos = pm.get_position(a)
-                        if pos is not None:
-                            pm.update_position_price(a, price)
-                            # Add market value of position (size * current_price)
-                            total_value += pos.size * price
-            
-            # If no positions, use starting cash
-            if total_value == 0:
-                total_value = self.starting_cash
-                
-            equity_points.append((t, total_value))
-            snapshots.append({"timestamp": t, "equity": total_value})
+        # If no snapshots were collected (e.g., no ticks), fall back to initial point
+        if not snapshots and ticks:
+            t0 = ticks[0]
+            snapshots.append({"timestamp": t0, "equity": self.starting_cash})
+            equity_points.append((t0, self.starting_cash))
+            position_snapshots.append({
+                "timestamp": t0,
+                "symbol": None,
+                "side": None,
+                "size": None,
+                "entry_price": None,
+                "current_price": None,
+                "pnl": None,
+                "realized_pnl": None,
+                "unrealized_pnl": None,
+                "pnl_percentage": None,
+                "kelly_size": None,
+                "market_value": None,
+                "entry_value": None,
+                "position_timestamp": None,
+                "cash_balance": pm.cash_balance,
+            })
 
         equity_curve = pd.Series(
             data=[v for _, v in equity_points], index=pd.to_datetime([t for t, _ in equity_points], utc=True)
         )
         snapshots_df = pd.DataFrame(snapshots).set_index(pd.to_datetime(pd.Series([s["timestamp"] for s in snapshots]), utc=True))
         snapshots_df.attrs["profile"] = profile_info
-        return BacktestResult(equity_curve=equity_curve, orders=orders, trades=[], snapshots=snapshots_df, errors=errors)
+        
+        # Create positions DataFrame
+        positions_df = pd.DataFrame(position_snapshots)
+        if not positions_df.empty and "timestamp" in positions_df.columns:
+            # Convert timestamp to datetime and set as index
+            positions_df["timestamp"] = pd.to_datetime(positions_df["timestamp"], utc=True)
+            positions_df = positions_df.set_index("timestamp")
+        
+        return BacktestResult(equity_curve=equity_curve, orders=orders, trades=[], snapshots=snapshots_df, positions=positions_df, errors=errors)
 
     async def run_with_control(
         self,

--- a/hypebot/indicators/__init__.py
+++ b/hypebot/indicators/__init__.py
@@ -1,7 +1,8 @@
 """Indicators module for technical analysis."""
 
 from .rsi_calculator import RSICalculator
+from .ema import EMACalculator
 from .base_indicator import BaseIndicator
 from .models import TradingSignal, IndicatorResult
 
-__all__ = ["RSICalculator", "BaseIndicator", "TradingSignal", "IndicatorResult"]
+__all__ = ["RSICalculator", "EMACalculator", "BaseIndicator", "TradingSignal", "IndicatorResult"]

--- a/hypebot/indicators/ema.py
+++ b/hypebot/indicators/ema.py
@@ -1,0 +1,55 @@
+"""EMA (Exponential Moving Average) calculator.
+
+Provides rolling EMA values and simple accessors for the latest and previous
+values. This indicator is used as a trend filter in hybrid strategies.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import pandas as pd
+
+from .base_indicator import BaseIndicator
+from .models import IndicatorResult, TradingSignal
+
+
+class EMACalculator(BaseIndicator):
+    """EMA calculator without intrinsic signal generation.
+
+    The EMA is used as a filter; this class focuses on calculating values.
+    """
+
+    def __init__(self, period: int = 20) -> None:
+        super().__init__("EMA", period)
+
+    def calculate(self, data: pd.DataFrame) -> List[IndicatorResult]:  # pragma: no cover - not used directly
+        self.validate_data(data, ["price"])  # Expect columns: [timestamp, price, symbol]
+        if len(data) < self.period:
+            return []
+        prices = data["price"].astype(float)
+        ema_series = prices.ewm(span=self.period, adjust=False).mean()
+        # Return as generic results structure if needed by future consumers
+        results: List[IndicatorResult] = []
+        for idx in range(self.period - 1, len(data)):
+            results.append(IndicatorResult())
+        return results
+
+    def generate_signal(self, current_value: float, previous_value: Optional[float] = None, metadata: Optional[dict] = None) -> Optional[TradingSignal]:  # pragma: no cover - EMA does not emit signals
+        return None
+
+    def calculate_last(self, data: pd.DataFrame) -> Optional[Tuple[float, Optional[float]]]:
+        """Return (current_ema, previous_ema) for the provided price data.
+
+        Expects columns: ['timestamp', 'price', 'symbol'] with at least `period` rows.
+        """
+        self.validate_data(data, ["price"])  # minimal validation
+        if len(data) < self.period:
+            return None
+        prices = data["price"].astype(float)
+        ema_series = prices.ewm(span=self.period, adjust=False).mean()
+        current = float(ema_series.iloc[-1])
+        prev = float(ema_series.iloc[-2]) if len(ema_series) >= 2 else None
+        return current, prev
+
+

--- a/hypebot/strategy/__init__.py
+++ b/hypebot/strategy/__init__.py
@@ -11,6 +11,7 @@ from .base import Strategy
 from .runner import StrategyRunner, RunnerMode
 from .client import TradingClientInterface
 from .models import StrategyOrder
+from .hybrid_rsi_ema_strategy import RSIEMAHybridStrategy
 
 __all__ = [
     "Strategy",
@@ -18,6 +19,7 @@ __all__ = [
     "RunnerMode",
     "TradingClientInterface",
     "StrategyOrder",
+    "RSIEMAHybridStrategy",
 ]
 
 

--- a/hypebot/strategy/hybrid_rsi_ema_strategy.py
+++ b/hypebot/strategy/hybrid_rsi_ema_strategy.py
@@ -1,0 +1,134 @@
+"""Hybrid RSI + EMA strategy implementing trend-filtered momentum.
+
+Rules (long-only):
+- Entry: (RSI > 50 or RSI crosses up from < oversold) AND Close > EMA(20)
+- Exit:  (RSI < 50) OR (Close < EMA(20))
+
+Sizing: all-in/all-out. Buy uses entire available cash for the asset; sell closes full position.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .base import Strategy
+from .models import StrategyOrder
+from ..indicators.rsi_calculator import RSICalculator
+from ..indicators.ema import EMACalculator
+from ..indicators.base_indicator import BaseIndicator
+from ..position.manager import PositionManager
+
+
+class RSIEMAHybridStrategy(Strategy):
+    """Trend-filtered RSI + EMA hybrid, all-in/all-out."""
+
+    def __init__(
+        self,
+        assets: List[str],
+        interval: str,
+        position_manager: PositionManager,
+        rsi_calculator: RSICalculator,
+        ema_calculator: EMACalculator,
+        rsi_trend_threshold: float = 50.0,
+        oversold_threshold: float = 30.0,
+        indicators: Optional[Dict[str, BaseIndicator]] = None,
+    ) -> None:
+        super().__init__(assets, interval, position_manager, indicators)
+        if position_manager is None:
+            raise ValueError("RSIEMAHybridStrategy requires a position_manager. Cannot be None.")
+        self.rsi = rsi_calculator
+        self.ema = ema_calculator
+        self.rsi_trend_threshold = float(rsi_trend_threshold)
+        self.oversold_threshold = float(oversold_threshold)
+
+    async def tick(self, as_of: datetime, historical: Dict[str, pd.DataFrame]) -> List[StrategyOrder]:
+        orders: List[StrategyOrder] = []
+
+        for symbol, df in historical.items():
+            if df is None or df.empty or "close" not in df.columns:
+                continue
+
+            current_price = float(df["close"].iloc[-1])
+
+            # Compute indicator inputs on a rolling window
+            rsi_window = max(getattr(self.rsi, "period", 14) + 2, 200)
+            ema_window = max(getattr(self.ema, "period", 20) + 2, 200)
+            window = max(rsi_window, ema_window)
+            tail_df = df.tail(window)
+
+            tmp = (
+                tail_df[["close"]]
+                .rename(columns={"close": "price"})
+                .reset_index()
+                .rename(columns={"index": "timestamp"})
+            )
+            tmp["symbol"] = symbol
+
+            # Calculate RSI last and previous
+            rsi_last = self.rsi.calculate_last(tmp)
+            if rsi_last is None:
+                continue
+            rsi_current, rsi_prev = rsi_last
+
+            # Calculate EMA last
+            ema_last = self.ema.calculate_last(tmp)
+            if ema_last is None:
+                continue
+            ema_current, _ = ema_last
+
+            # Determine RSI conditions
+            rsi_above_trend = rsi_current > self.rsi_trend_threshold
+            crossed_up_from_oversold = False
+            if rsi_prev is not None:
+                crossed_up_from_oversold = rsi_prev < self.oversold_threshold and rsi_current >= self.oversold_threshold
+
+            price_above_ema = current_price > ema_current
+            price_below_ema = current_price < ema_current
+
+            # Check existing position
+            pos = self.position_manager.get_position(symbol)
+
+            # Entry conditions: long-only
+            should_buy = (rsi_above_trend or crossed_up_from_oversold) and price_above_ema
+            # Exit conditions
+            should_sell = (pos is not None and pos.side == "LONG") and (rsi_current < self.rsi_trend_threshold or price_below_ema)
+
+            if pos is None and should_buy:
+                # Use entire available cash
+                cash = float(self.position_manager.cash_balance)
+                if cash <= 0:
+                    continue
+                quantity = cash / current_price
+                if quantity <= 0:
+                    continue
+                orders.append(
+                    StrategyOrder(
+                        symbol=symbol,
+                        side="BUY",
+                        order_type="MARKET",
+                        quantity=quantity,
+                        price=current_price,
+                        timestamp=as_of,
+                    )
+                )
+            elif should_sell:
+                # Close entire position
+                quantity = float(pos.size) if pos is not None else 0.0
+                if quantity > 0:
+                    orders.append(
+                        StrategyOrder(
+                            symbol=symbol,
+                            side="SELL",
+                            order_type="MARKET",
+                            quantity=quantity,
+                            price=current_price,
+                            timestamp=as_of,
+                        )
+                    )
+
+        return orders
+
+

--- a/hypebot/strategy/runner.py
+++ b/hypebot/strategy/runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Callable
 
 import pandas as pd
 import time
@@ -53,7 +53,7 @@ class StrategyRunner:
         # Accumulate executed orders so callers can recover partial progress on errors
         self._orders: List[Order] = []
 
-    async def run(self, ticks: Iterable[datetime]) -> List[Order]:
+    async def run(self, ticks: Iterable[datetime], on_after_tick: Optional[Callable[[datetime], None]] = None) -> List[Order]:
         # Reset accumulated orders each run
         self._orders = []
         await self.strategy.on_start()
@@ -75,6 +75,12 @@ class StrategyRunner:
                 placed = await self._execute(strategy_orders)
                 self.profile["execute_s"] += time.perf_counter() - t2
                 self._orders.extend(placed)
+                # Allow caller to collect per-tick snapshots after state updates
+                if callable(on_after_tick):
+                    try:
+                        on_after_tick(t)
+                    except Exception:
+                        logger.exception("on_after_tick callback raised")
         finally:
             await self.strategy.on_stop()
         return self._orders

--- a/hypebot/tests/test_backtest_utility_position_export.py
+++ b/hypebot/tests/test_backtest_utility_position_export.py
@@ -1,0 +1,453 @@
+"""Tests for position CSV export functionality in backtest utility."""
+
+import pytest
+import pandas as pd
+import json
+import tempfile
+import os
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch, mock_open
+
+from hypebot.backtesting.backtester import BacktestResult, CommissionModel
+from hypebot.exchange.models import Order
+
+
+@pytest.fixture
+def sample_backtest_result():
+    """Create a sample BacktestResult with position data."""
+    equity_curve = pd.Series([10000, 10100, 10200], name="equity")
+    orders = [
+        Order(
+            symbol="BTC-USD",
+            side="BUY",
+            order_type="MARKET",
+            quantity=0.1,
+            price=50000.0,
+            status="FILLED",
+            filled_quantity=0.1,
+            average_fill_price=50000.0,
+            timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc)
+        )
+    ]
+    trades = []
+    
+    # Create snapshots DataFrame
+    snapshots_data = {
+        "timestamp": pd.date_range("2024-01-01", periods=3, freq="D", tz="UTC"),
+        "equity": [10000, 10100, 10200]
+    }
+    snapshots = pd.DataFrame(snapshots_data).set_index("timestamp")
+    
+    # Create positions DataFrame
+    positions_data = [
+        {
+            "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "symbol": None,
+            "side": None,
+            "size": None,
+            "entry_price": None,
+            "current_price": None,
+            "pnl": None,
+            "realized_pnl": None,
+            "unrealized_pnl": None,
+            "pnl_percentage": None,
+            "kelly_size": None,
+            "market_value": None,
+            "entry_value": None,
+            "position_timestamp": None,
+            "cash_balance": 10000.0
+        },
+        {
+            "timestamp": datetime(2024, 1, 2, tzinfo=timezone.utc),
+            "symbol": "BTC-USD",
+            "side": "LONG",
+            "size": 0.1,
+            "entry_price": 50000.0,
+            "current_price": 51000.0,
+            "pnl": 100.0,
+            "realized_pnl": 0.0,
+            "unrealized_pnl": 100.0,
+            "pnl_percentage": 2.0,
+            "kelly_size": 0.1,
+            "market_value": 5100.0,
+            "entry_value": 5000.0,
+            "position_timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "cash_balance": 5000.0
+        },
+        {
+            "timestamp": datetime(2024, 1, 3, tzinfo=timezone.utc),
+            "symbol": None,
+            "side": None,
+            "size": None,
+            "entry_price": None,
+            "current_price": None,
+            "pnl": None,
+            "realized_pnl": None,
+            "unrealized_pnl": None,
+            "pnl_percentage": None,
+            "kelly_size": None,
+            "market_value": None,
+            "entry_value": None,
+            "position_timestamp": None,
+            "cash_balance": 10100.0
+        }
+    ]
+    positions = pd.DataFrame(positions_data)
+    if not positions.empty and "timestamp" in positions.columns:
+        positions["timestamp"] = pd.to_datetime(positions["timestamp"], utc=True)
+        positions = positions.set_index("timestamp")
+    
+    errors = []
+    
+    return BacktestResult(
+        equity_curve=equity_curve,
+        orders=orders,
+        trades=trades,
+        snapshots=snapshots,
+        positions=positions,
+        errors=errors
+    )
+
+
+@pytest.fixture
+def empty_backtest_result():
+    """Create an empty BacktestResult."""
+    return BacktestResult(
+        equity_curve=pd.Series(dtype=float),
+        orders=[],
+        trades=[],
+        snapshots=pd.DataFrame(),
+        positions=pd.DataFrame(),
+        errors=[]
+    )
+
+
+class TestPositionCSVExport:
+    """Test position CSV export functionality."""
+    
+    def test_position_csv_export_with_data(self, sample_backtest_result):
+        """Test exporting position data to CSV when data is available."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            positions_csv_path = os.path.join(temp_dir, "positions_test_strategy.csv")
+            
+            # Mock the CSV export logic from backtest.py
+            try:
+                if hasattr(sample_backtest_result, "positions") and isinstance(sample_backtest_result.positions, pd.DataFrame) and not sample_backtest_result.positions.empty:
+                    # Reset index to include timestamp as a column
+                    positions_df = sample_backtest_result.positions.reset_index()
+                    # Ensure timestamp column exists and is properly formatted
+                    if "timestamp" in positions_df.columns:
+                        positions_df["timestamp"] = pd.to_datetime(positions_df["timestamp"])
+                    positions_df.to_csv(positions_csv_path, index=False)
+                    
+                    # Verify file was created
+                    assert os.path.exists(positions_csv_path)
+                    
+                    # Read and verify content
+                    df = pd.read_csv(positions_csv_path)
+                    assert len(df) == 3
+                    assert "timestamp" in df.columns
+                    assert "symbol" in df.columns
+                    assert "cash_balance" in df.columns
+                    assert "pnl" in df.columns
+                    
+                    # Check specific values
+                    assert pd.isna(df.iloc[0]["symbol"])  # First row has no position
+                    assert df.iloc[1]["symbol"] == "BTC-USD"  # Second row has position
+                    assert df.iloc[1]["side"] == "LONG"
+                    assert df.iloc[1]["size"] == 0.1
+                    assert df.iloc[1]["pnl"] == 100.0
+                    
+            except Exception as e:
+                pytest.fail(f"Failed to export positions CSV: {e}")
+    
+    def test_position_csv_export_empty_data(self, empty_backtest_result):
+        """Test exporting position data when no data is available."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            positions_csv_path = os.path.join(temp_dir, "positions_empty.csv")
+            
+            # Mock the CSV export logic for empty data
+            try:
+                if hasattr(empty_backtest_result, "positions") and isinstance(empty_backtest_result.positions, pd.DataFrame) and not empty_backtest_result.positions.empty:
+                    # This should not execute for empty data
+                    positions_df = empty_backtest_result.positions.reset_index()
+                    positions_df.to_csv(positions_csv_path, index=False)
+                else:
+                    # Create empty CSV with proper headers
+                    empty_positions = pd.DataFrame(columns=[
+                        "timestamp", "symbol", "side", "size", "entry_price", "current_price",
+                        "pnl", "realized_pnl", "unrealized_pnl", "pnl_percentage", "kelly_size",
+                        "market_value", "entry_value", "position_timestamp", "cash_balance"
+                    ])
+                    empty_positions.to_csv(positions_csv_path, index=False)
+                
+                # Verify file was created
+                assert os.path.exists(positions_csv_path)
+                
+                # Read and verify content
+                df = pd.read_csv(positions_csv_path)
+                assert len(df) == 0  # Empty DataFrame
+                assert "timestamp" in df.columns
+                assert "symbol" in df.columns
+                assert "cash_balance" in df.columns
+                
+            except Exception as e:
+                pytest.fail(f"Failed to export empty positions CSV: {e}")
+    
+    def test_position_csv_columns(self, sample_backtest_result):
+        """Test that position CSV contains all required columns."""
+        expected_columns = [
+            "timestamp", "symbol", "side", "size", "entry_price", "current_price",
+            "pnl", "realized_pnl", "unrealized_pnl", "pnl_percentage", "kelly_size",
+            "market_value", "entry_value", "position_timestamp", "cash_balance"
+        ]
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            positions_csv_path = os.path.join(temp_dir, "positions_columns_test.csv")
+            
+            positions_df = sample_backtest_result.positions.reset_index()
+            if "timestamp" in positions_df.columns:
+                positions_df["timestamp"] = pd.to_datetime(positions_df["timestamp"])
+            positions_df.to_csv(positions_csv_path, index=False)
+            
+            # Read and verify columns
+            df = pd.read_csv(positions_csv_path)
+            for column in expected_columns:
+                assert column in df.columns, f"Missing column: {column}"
+    
+    def test_position_csv_timestamp_formatting(self, sample_backtest_result):
+        """Test that timestamps are properly formatted in CSV export."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            positions_csv_path = os.path.join(temp_dir, "positions_timestamp_test.csv")
+            
+            positions_df = sample_backtest_result.positions.reset_index()
+            if "timestamp" in positions_df.columns:
+                positions_df["timestamp"] = pd.to_datetime(positions_df["timestamp"])
+            positions_df.to_csv(positions_csv_path, index=False)
+            
+            # Read and verify timestamp formatting
+            df = pd.read_csv(positions_csv_path)
+            assert "timestamp" in df.columns
+            
+            # Check that timestamps are properly formatted
+            timestamps = pd.to_datetime(df["timestamp"])
+            assert len(timestamps) == 3
+            assert timestamps[0].year == 2024
+            assert timestamps[0].month == 1
+            assert timestamps[0].day == 1
+
+
+class TestBuyAndHoldPositionExport:
+    """Test position CSV export for buy-and-hold control strategy."""
+    
+    def test_buy_and_hold_position_export(self):
+        """Test position export for buy-and-hold strategy."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            control_positions_csv_path = os.path.join(temp_dir, "positions_buy_and_hold.csv")
+            
+            # Create mock buy-and-hold result
+            equity_curve = pd.Series([10000, 10100, 10200], name="equity")
+            orders = []
+            trades = []
+            snapshots = pd.DataFrame({"equity": [10000, 10100, 10200]})
+            
+            # Buy-and-hold positions (should hold position throughout)
+            positions_data = [
+                {
+                    "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    "symbol": "BTC-USD",
+                    "side": "LONG",
+                    "size": 0.2,
+                    "entry_price": 50000.0,
+                    "current_price": 50000.0,
+                    "pnl": 0.0,
+                    "realized_pnl": 0.0,
+                    "unrealized_pnl": 0.0,
+                    "pnl_percentage": 0.0,
+                    "kelly_size": 0.2,
+                    "market_value": 10000.0,
+                    "entry_value": 10000.0,
+                    "position_timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    "cash_balance": 0.0
+                },
+                {
+                    "timestamp": datetime(2024, 1, 2, tzinfo=timezone.utc),
+                    "symbol": "BTC-USD",
+                    "side": "LONG",
+                    "size": 0.2,
+                    "entry_price": 50000.0,
+                    "current_price": 51000.0,
+                    "pnl": 200.0,
+                    "realized_pnl": 0.0,
+                    "unrealized_pnl": 200.0,
+                    "pnl_percentage": 4.0,
+                    "kelly_size": 0.2,
+                    "market_value": 10200.0,
+                    "entry_value": 10000.0,
+                    "position_timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    "cash_balance": 0.0
+                }
+            ]
+            positions = pd.DataFrame(positions_data)
+            if not positions.empty and "timestamp" in positions.columns:
+                positions["timestamp"] = pd.to_datetime(positions["timestamp"], utc=True)
+                positions = positions.set_index("timestamp")
+            
+            errors = []
+            
+            control_result = BacktestResult(
+                equity_curve=equity_curve,
+                orders=orders,
+                trades=trades,
+                snapshots=snapshots,
+                positions=positions,
+                errors=errors
+            )
+            
+            # Mock the export logic
+            try:
+                if hasattr(control_result, "positions") and isinstance(control_result.positions, pd.DataFrame) and not control_result.positions.empty:
+                    positions_df = control_result.positions.reset_index()
+                    if "timestamp" in positions_df.columns:
+                        positions_df["timestamp"] = pd.to_datetime(positions_df["timestamp"])
+                    positions_df.to_csv(control_positions_csv_path, index=False)
+                
+                # Verify file was created
+                assert os.path.exists(control_positions_csv_path)
+                
+                # Read and verify content
+                df = pd.read_csv(control_positions_csv_path)
+                assert len(df) == 2
+                assert df.iloc[0]["symbol"] == "BTC-USD"
+                assert df.iloc[0]["side"] == "LONG"
+                assert df.iloc[0]["size"] == 0.2
+                assert df.iloc[0]["pnl"] == 0.0
+                assert df.iloc[1]["pnl"] == 200.0
+                
+            except Exception as e:
+                pytest.fail(f"Failed to export buy-and-hold positions CSV: {e}")
+
+
+class TestPositionExportErrorHandling:
+    """Test error handling in position CSV export."""
+    
+    def test_position_export_with_missing_positions_attribute(self):
+        """Test position export when result doesn't have positions attribute."""
+        # Create a mock result without positions attribute
+        mock_result = Mock()
+        mock_result.positions = None
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            positions_csv_path = os.path.join(temp_dir, "positions_error_test.csv")
+            
+            try:
+                # This should create an empty CSV
+                if hasattr(mock_result, "positions") and isinstance(mock_result.positions, pd.DataFrame) and not mock_result.positions.empty:
+                    # This should not execute
+                    pass
+                else:
+                    # Create empty CSV with proper headers
+                    empty_positions = pd.DataFrame(columns=[
+                        "timestamp", "symbol", "side", "size", "entry_price", "current_price",
+                        "pnl", "realized_pnl", "unrealized_pnl", "pnl_percentage", "kelly_size",
+                        "market_value", "entry_value", "position_timestamp", "cash_balance"
+                    ])
+                    empty_positions.to_csv(positions_csv_path, index=False)
+                
+                # Verify file was created with empty data
+                assert os.path.exists(positions_csv_path)
+                df = pd.read_csv(positions_csv_path)
+                assert len(df) == 0
+                
+            except Exception as e:
+                pytest.fail(f"Failed to handle missing positions attribute: {e}")
+    
+    def test_position_export_with_invalid_dataframe(self):
+        """Test position export with invalid DataFrame."""
+        # Create a mock result with invalid positions data
+        mock_result = Mock()
+        mock_result.positions = "invalid_dataframe"
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            positions_csv_path = os.path.join(temp_dir, "positions_invalid_test.csv")
+            
+            try:
+                # This should create an empty CSV due to invalid data
+                if hasattr(mock_result, "positions") and isinstance(mock_result.positions, pd.DataFrame) and not mock_result.positions.empty:
+                    # This should not execute
+                    pass
+                else:
+                    # Create empty CSV with proper headers
+                    empty_positions = pd.DataFrame(columns=[
+                        "timestamp", "symbol", "side", "size", "entry_price", "current_price",
+                        "pnl", "realized_pnl", "unrealized_pnl", "pnl_percentage", "kelly_size",
+                        "market_value", "entry_value", "position_timestamp", "cash_balance"
+                    ])
+                    empty_positions.to_csv(positions_csv_path, index=False)
+                
+                # Verify file was created with empty data
+                assert os.path.exists(positions_csv_path)
+                df = pd.read_csv(positions_csv_path)
+                assert len(df) == 0
+                
+            except Exception as e:
+                pytest.fail(f"Failed to handle invalid DataFrame: {e}")
+
+
+class TestPositionCSVIntegration:
+    """Test integration of position CSV export with full backtest workflow."""
+    
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('pandas.DataFrame.to_csv')
+    def test_full_backtest_workflow_with_positions(self, mock_to_csv, mock_file, sample_backtest_result):
+        """Test that position CSV export integrates with full backtest workflow."""
+        # This test simulates the full workflow from backtest.py
+        
+        # Mock the backtest result
+        result = sample_backtest_result
+        strategy_name = "TestStrategy"
+        output_dir = "/tmp/test_output"
+        
+        # Simulate the position CSV export logic
+        positions_csv_path = os.path.join(output_dir, f"positions_{strategy_name.replace(' ', '_')}.csv")
+        
+        try:
+            if hasattr(result, "positions") and isinstance(result.positions, pd.DataFrame) and not result.positions.empty:
+                positions_df = result.positions.reset_index()
+                if "timestamp" in positions_df.columns:
+                    positions_df["timestamp"] = pd.to_datetime(positions_df["timestamp"])
+                positions_df.to_csv(positions_csv_path, index=False)
+            else:
+                empty_positions = pd.DataFrame(columns=[
+                    "timestamp", "symbol", "side", "size", "entry_price", "current_price",
+                    "pnl", "realized_pnl", "unrealized_pnl", "pnl_percentage", "kelly_size",
+                    "market_value", "entry_value", "position_timestamp", "cash_balance"
+                ])
+                empty_positions.to_csv(positions_csv_path, index=False)
+        
+        except Exception as e:
+            pytest.fail(f"Position CSV export failed in full workflow: {e}")
+        
+        # Verify that to_csv was called (mocked)
+        mock_to_csv.assert_called()
+    
+    def test_position_csv_filename_generation(self):
+        """Test that position CSV filenames are generated correctly."""
+        strategy_names = [
+            "RSIStrategy",
+            "RSI EMA Hybrid Strategy",
+            "Buy And Hold Strategy",
+            "Test Strategy"
+        ]
+        
+        expected_filenames = [
+            "positions_RSIStrategy.csv",
+            "positions_RSI_EMA_Hybrid_Strategy.csv",
+            "positions_Buy_And_Hold_Strategy.csv",
+            "positions_Test_Strategy.csv"
+        ]
+        
+        for strategy_name, expected_filename in zip(strategy_names, expected_filenames):
+            # Simulate filename generation from backtest.py
+            generated_filename = f"positions_{strategy_name.replace(' ', '_')}.csv"
+            assert generated_filename == expected_filename

--- a/hypebot/tests/test_backtester_position_tracking.py
+++ b/hypebot/tests/test_backtester_position_tracking.py
@@ -1,0 +1,502 @@
+"""Tests for position tracking functionality in the backtester."""
+
+import pytest
+import pandas as pd
+from datetime import datetime, timezone
+from unittest.mock import Mock, AsyncMock
+
+from hypebot.backtesting.backtester import BackTester, BacktestResult, CommissionModel
+from hypebot.config import Config, TradingConfig, DatabaseConfig
+from hypebot.data.storage import DataStorage
+from hypebot.position.manager import PositionManager
+from hypebot.position.models import Position
+from hypebot.strategy.base import Strategy
+from hypebot.strategy.buy_and_hold_strategy import BuyAndHoldStrategy
+from hypebot.exchange.models import Order
+
+
+class MockStrategy(Strategy):
+    """Mock strategy for testing."""
+    
+    def __init__(self):
+        # Initialize with required parameters
+        super().__init__(
+            assets=["BTC-USD"],
+            interval="1d",
+            position_manager=None
+        )
+        self.tick_count = 0
+    
+    async def tick(self, data: dict) -> list:
+        """Mock tick implementation."""
+        self.tick_count += 1
+        # Open position on first tick, close on second
+        if self.tick_count == 1:
+            return [{"symbol": "BTC-USD", "side": "BUY", "quantity": 0.1, "price": 50000.0}]
+        elif self.tick_count == 2:
+            return [{"symbol": "BTC-USD", "side": "SELL", "quantity": 0.1, "price": 51000.0}]
+        return []
+
+
+@pytest.fixture
+def mock_config():
+    """Create a mock config for testing."""
+    config = Mock(spec=Config)
+    config.trading = Mock(spec=TradingConfig)
+    config.database = Mock(spec=DatabaseConfig)
+    return config
+
+
+@pytest.fixture
+def mock_storage():
+    """Create a mock storage for testing."""
+    storage = Mock(spec=DataStorage)
+    
+    # Mock historical data
+    dates = pd.date_range(start="2024-01-01", periods=5, freq="D", tz="UTC")
+    data = pd.DataFrame({
+        "open": [49000, 50000, 51000, 52000, 53000],
+        "high": [49500, 50500, 51500, 52500, 53500],
+        "low": [48500, 49500, 50500, 51500, 52500],
+        "close": [50000, 51000, 52000, 53000, 54000],
+        "volume": [100, 110, 120, 130, 140]
+    }, index=dates)
+    
+    storage.get_historical_ohlcv_data.return_value = data
+    return storage
+
+
+@pytest.fixture
+def backtester(mock_config, mock_storage):
+    """Create a backtester instance for testing."""
+    commission = CommissionModel(type="percent", value=0.001)
+    return BackTester(
+        config=mock_config,
+        storage=mock_storage,
+        commission=commission,
+        starting_cash=10000.0
+    )
+
+
+class TestBacktestResult:
+    """Test BacktestResult dataclass with positions field."""
+    
+    def test_backtest_result_creation(self):
+        """Test that BacktestResult can be created with positions field."""
+        equity_curve = pd.Series([10000, 10100, 10200], name="equity")
+        orders = []
+        trades = []
+        snapshots = pd.DataFrame({"equity": [10000, 10100, 10200]})
+        positions = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=3, freq="D"),
+            "symbol": ["BTC-USD", "BTC-USD", None],
+            "cash_balance": [9500, 9000, 10000]
+        })
+        errors = []
+        
+        result = BacktestResult(
+            equity_curve=equity_curve,
+            orders=orders,
+            trades=trades,
+            snapshots=snapshots,
+            positions=positions,
+            errors=errors
+        )
+        
+        assert result.positions is not None
+        assert len(result.positions) == 3
+        assert "symbol" in result.positions.columns
+        assert "cash_balance" in result.positions.columns
+
+
+class TestPositionTracking:
+    """Test position tracking functionality in the backtester."""
+    
+    @pytest.mark.asyncio
+    async def test_position_tracking_with_positions(self, backtester, mock_storage):
+        """Test position tracking when positions are opened and closed."""
+        strategy = MockStrategy()
+        
+        # Mock the strategy runner to simulate position opening/closing
+        original_run = backtester.run_single
+        
+        async def mock_run_single(*args, **kwargs):
+            # Create a mock result with positions
+            equity_curve = pd.Series([10000, 9900, 10100], name="equity")
+            orders = [
+                Order(
+                    symbol="BTC-USD",
+                    side="BUY",
+                    order_type="MARKET",
+                    quantity=0.1,
+                    price=50000.0,
+                    status="FILLED",
+                    filled_quantity=0.1,
+                    average_fill_price=50000.0,
+                    timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc)
+                )
+            ]
+            trades = []
+            snapshots = pd.DataFrame({"equity": [10000, 9900, 10100]})
+            
+            # Create position tracking data
+            positions_data = [
+                {
+                    "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    "symbol": None,
+                    "side": None,
+                    "size": None,
+                    "entry_price": None,
+                    "current_price": None,
+                    "pnl": None,
+                    "realized_pnl": None,
+                    "unrealized_pnl": None,
+                    "pnl_percentage": None,
+                    "kelly_size": None,
+                    "market_value": None,
+                    "entry_value": None,
+                    "position_timestamp": None,
+                    "cash_balance": 10000.0
+                },
+                {
+                    "timestamp": datetime(2024, 1, 2, tzinfo=timezone.utc),
+                    "symbol": "BTC-USD",
+                    "side": "LONG",
+                    "size": 0.1,
+                    "entry_price": 50000.0,
+                    "current_price": 51000.0,
+                    "pnl": 100.0,
+                    "realized_pnl": 0.0,
+                    "unrealized_pnl": 100.0,
+                    "pnl_percentage": 2.0,
+                    "kelly_size": 0.1,
+                    "market_value": 5100.0,
+                    "entry_value": 5000.0,
+                    "position_timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    "cash_balance": 5000.0
+                },
+                {
+                    "timestamp": datetime(2024, 1, 3, tzinfo=timezone.utc),
+                    "symbol": None,
+                    "side": None,
+                    "size": None,
+                    "entry_price": None,
+                    "current_price": None,
+                    "pnl": None,
+                    "realized_pnl": None,
+                    "unrealized_pnl": None,
+                    "pnl_percentage": None,
+                    "kelly_size": None,
+                    "market_value": None,
+                    "entry_value": None,
+                    "position_timestamp": None,
+                    "cash_balance": 10100.0
+                }
+            ]
+            positions_df = pd.DataFrame(positions_data)
+            if not positions_df.empty and "timestamp" in positions_df.columns:
+                positions_df = positions_df.set_index(pd.to_datetime(positions_df["timestamp"], utc=True))
+            
+            errors = []
+            
+            return BacktestResult(
+                equity_curve=equity_curve,
+                orders=orders,
+                trades=trades,
+                snapshots=snapshots,
+                positions=positions_df,
+                errors=errors
+            )
+        
+        backtester.run_single = mock_run_single
+        
+        # Run the backtest
+        result = await backtester.run_single(
+            strategy=strategy,
+            assets=["BTC-USD"],
+            interval="1d"
+        )
+        
+        # Verify position tracking
+        assert result.positions is not None
+        assert len(result.positions) == 3
+        
+        # Check first tick (no position)
+        first_tick = result.positions.iloc[0]
+        assert pd.isna(first_tick["symbol"])
+        assert first_tick["cash_balance"] == 10000.0
+        
+        # Check second tick (position open)
+        second_tick = result.positions.iloc[1]
+        assert second_tick["symbol"] == "BTC-USD"
+        assert second_tick["side"] == "LONG"
+        assert second_tick["size"] == 0.1
+        assert second_tick["entry_price"] == 50000.0
+        assert second_tick["current_price"] == 51000.0
+        assert second_tick["pnl"] == 100.0
+        assert second_tick["cash_balance"] == 5000.0
+        
+        # Check third tick (position closed)
+        third_tick = result.positions.iloc[2]
+        assert pd.isna(third_tick["symbol"])
+        assert third_tick["cash_balance"] == 10100.0
+    
+    @pytest.mark.asyncio
+    async def test_position_tracking_no_data(self, backtester, mock_storage):
+        """Test position tracking when no data is available."""
+        strategy = MockStrategy()
+        
+        # Mock storage to return empty data
+        mock_storage.get_historical_ohlcv_data.return_value = pd.DataFrame()
+        
+        result = await backtester.run_single(
+            strategy=strategy,
+            assets=["BTC-USD"],
+            interval="1d"
+        )
+        
+        # Verify empty result
+        assert result.positions is not None
+        assert result.positions.empty
+        assert result.equity_curve.empty
+        assert result.orders == []
+        assert result.errors == []
+    
+    @pytest.mark.asyncio
+    async def test_position_tracking_error_handling(self, backtester, mock_storage):
+        """Test position tracking when errors occur during backtesting."""
+        strategy = MockStrategy()
+        
+        # Mock the strategy runner to raise an error
+        original_run = backtester.run_single
+        
+        async def mock_run_single_with_error(*args, **kwargs):
+            equity_curve = pd.Series([10000], name="equity")
+            orders = []
+            trades = []
+            snapshots = pd.DataFrame({"equity": [10000]})
+            positions = pd.DataFrame()
+            errors = ["Test error"]
+            
+            return BacktestResult(
+                equity_curve=equity_curve,
+                orders=orders,
+                trades=trades,
+                snapshots=snapshots,
+                positions=positions,
+                errors=errors
+            )
+        
+        backtester.run_single = mock_run_single_with_error
+        
+        result = await backtester.run_single(
+            strategy=strategy,
+            assets=["BTC-USD"],
+            interval="1d"
+        )
+        
+        # Verify error handling
+        assert result.errors == ["Test error"]
+        assert result.positions is not None
+
+
+class TestPositionDataStructure:
+    """Test the structure and content of position tracking data."""
+    
+    def test_position_data_columns(self):
+        """Test that position data contains all required columns."""
+        expected_columns = [
+            "timestamp", "symbol", "side", "size", "entry_price", "current_price",
+            "pnl", "realized_pnl", "unrealized_pnl", "pnl_percentage", "kelly_size",
+            "market_value", "entry_value", "position_timestamp", "cash_balance"
+        ]
+        
+        # Create a sample position data structure
+        position_data = {
+            "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "symbol": "BTC-USD",
+            "side": "LONG",
+            "size": 0.1,
+            "entry_price": 50000.0,
+            "current_price": 51000.0,
+            "pnl": 100.0,
+            "realized_pnl": 0.0,
+            "unrealized_pnl": 100.0,
+            "pnl_percentage": 2.0,
+            "kelly_size": 0.1,
+            "market_value": 5100.0,
+            "entry_value": 5000.0,
+            "position_timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "cash_balance": 5000.0
+        }
+        
+        # Verify all expected columns are present
+        for column in expected_columns:
+            assert column in position_data
+    
+    def test_empty_position_data(self):
+        """Test position data structure when no positions are held."""
+        empty_position_data = {
+            "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+            "symbol": None,
+            "side": None,
+            "size": None,
+            "entry_price": None,
+            "current_price": None,
+            "pnl": None,
+            "realized_pnl": None,
+            "unrealized_pnl": None,
+            "pnl_percentage": None,
+            "kelly_size": None,
+            "market_value": None,
+            "entry_value": None,
+            "position_timestamp": None,
+            "cash_balance": 10000.0
+        }
+        
+        # Verify empty position data structure
+        assert empty_position_data["symbol"] is None
+        assert empty_position_data["cash_balance"] == 10000.0
+        assert all(value is None for key, value in empty_position_data.items() 
+                  if key not in ["timestamp", "cash_balance"])
+
+
+class TestPositionDataFrameCreation:
+    """Test DataFrame creation and indexing for position data."""
+    
+    def test_position_dataframe_creation(self):
+        """Test that position data is properly converted to DataFrame."""
+        position_data = [
+            {
+                "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "symbol": None,
+                "cash_balance": 10000.0
+            },
+            {
+                "timestamp": datetime(2024, 1, 2, tzinfo=timezone.utc),
+                "symbol": "BTC-USD",
+                "cash_balance": 5000.0
+            }
+        ]
+        
+        df = pd.DataFrame(position_data)
+        assert len(df) == 2
+        assert "timestamp" in df.columns
+        assert "symbol" in df.columns
+        assert "cash_balance" in df.columns
+    
+    def test_position_dataframe_indexing(self):
+        """Test that position DataFrame is properly indexed by timestamp."""
+        position_data = [
+            {
+                "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "symbol": None,
+                "cash_balance": 10000.0
+            }
+        ]
+        
+        df = pd.DataFrame(position_data)
+        if not df.empty and "timestamp" in df.columns:
+            df = df.set_index(pd.to_datetime(df["timestamp"], utc=True))
+        
+        # The index name will be 'timestamp' when using set_index with the column
+        assert df.index.name == 'timestamp'  # Index name is 'timestamp'
+        assert len(df.index) == 1
+        assert isinstance(df.index[0], pd.Timestamp)
+
+
+@pytest.mark.asyncio
+async def test_integration_with_buy_and_hold():
+    """Test position tracking integration with buy-and-hold strategy."""
+    # This test verifies that position tracking works with the control strategy
+    config = Mock(spec=Config)
+    config.trading = Mock(spec=TradingConfig)
+    config.database = Mock(spec=DatabaseConfig)
+    
+    storage = Mock(spec=DataStorage)
+    dates = pd.date_range(start="2024-01-01", periods=3, freq="D", tz="UTC")
+    data = pd.DataFrame({
+        "open": [49000, 50000, 51000],
+        "high": [49500, 50500, 51500],
+        "low": [48500, 49500, 50500],
+        "close": [50000, 51000, 52000],
+        "volume": [100, 110, 120]
+    }, index=dates)
+    storage.get_historical_ohlcv_data.return_value = data
+    
+    commission = CommissionModel(type="percent", value=0.001)
+    backtester = BackTester(
+        config=config,
+        storage=storage,
+        commission=commission,
+        starting_cash=10000.0
+    )
+    
+    strategy = BuyAndHoldStrategy(
+        assets=["BTC-USD"],
+        interval="1d",
+        position_manager=PositionManager(
+            config.trading,
+            storage,
+            load_existing=False,
+            starting_cash=10000.0,
+            persist=False
+        ),
+        starting_cash=10000.0
+    )
+    
+    # Mock the run_single method to return a result with positions
+    async def mock_run_single(*args, **kwargs):
+        equity_curve = pd.Series([10000, 10100, 10200], name="equity")
+        orders = []
+        trades = []
+        snapshots = pd.DataFrame({"equity": [10000, 10100, 10200]})
+        
+        positions_data = [
+            {
+                "timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "symbol": "BTC-USD",
+                "side": "LONG",
+                "size": 0.2,
+                "entry_price": 50000.0,
+                "current_price": 50000.0,
+                "pnl": 0.0,
+                "realized_pnl": 0.0,
+                "unrealized_pnl": 0.0,
+                "pnl_percentage": 0.0,
+                "kelly_size": 0.2,
+                "market_value": 10000.0,
+                "entry_value": 10000.0,
+                "position_timestamp": datetime(2024, 1, 1, tzinfo=timezone.utc),
+                "cash_balance": 0.0
+            }
+        ]
+        positions_df = pd.DataFrame(positions_data)
+        if not positions_df.empty and "timestamp" in positions_df.columns:
+            positions_df = positions_df.set_index(pd.to_datetime(positions_df["timestamp"], utc=True))
+        
+        errors = []
+        
+        return BacktestResult(
+            equity_curve=equity_curve,
+            orders=orders,
+            trades=trades,
+            snapshots=snapshots,
+            positions=positions_df,
+            errors=errors
+        )
+    
+    backtester.run_single = mock_run_single
+    
+    result = await backtester.run_single(
+        strategy=strategy,
+        assets=["BTC-USD"],
+        interval="1d"
+    )
+    
+    # Verify buy-and-hold position tracking
+    assert result.positions is not None
+    assert len(result.positions) == 1
+    assert result.positions.iloc[0]["symbol"] == "BTC-USD"
+    assert result.positions.iloc[0]["side"] == "LONG"
+    assert result.positions.iloc[0]["size"] == 0.2

--- a/hypebot/tests/test_ema_calculator.py
+++ b/hypebot/tests/test_ema_calculator.py
@@ -1,0 +1,40 @@
+"""Tests for EMA calculator."""
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+
+from hypebot.indicators.ema import EMACalculator
+
+
+class TestEMACalculator:
+    def test_calculate_last_basic(self):
+        ema = EMACalculator(period=5)
+        base = datetime.utcnow()
+        prices = [10, 11, 12, 13, 14, 15, 16]
+        df = pd.DataFrame({
+            "symbol": ["BTC"] * len(prices),
+            "timestamp": [base + timedelta(days=i) for i in range(len(prices))],
+            "price": prices,
+        })
+
+        last = ema.calculate_last(df)
+        assert last is not None
+        current, prev = last
+        assert isinstance(current, float)
+        assert prev is None or isinstance(prev, float)
+        # EMA should be between min and max of prices
+        assert min(prices) <= current <= max(prices)
+
+    def test_insufficient_data(self):
+        ema = EMACalculator(period=10)
+        base = datetime.utcnow()
+        prices = [10, 11, 12]  # fewer than period
+        df = pd.DataFrame({
+            "symbol": ["BTC"] * len(prices),
+            "timestamp": [base + timedelta(days=i) for i in range(len(prices))],
+            "price": prices,
+        })
+        assert ema.calculate_last(df) is None
+
+

--- a/hypebot/tests/test_hybrid_rsi_ema_strategy.py
+++ b/hypebot/tests/test_hybrid_rsi_ema_strategy.py
@@ -1,0 +1,96 @@
+"""Tests for RSI + EMA Hybrid Strategy."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+import asyncio
+from typing import Dict
+
+import pandas as pd
+
+from hypebot.strategy.hybrid_rsi_ema_strategy import RSIEMAHybridStrategy
+from hypebot.indicators.rsi_calculator import RSICalculator
+from hypebot.indicators.ema import EMACalculator
+from hypebot.position.manager import PositionManager
+from hypebot.data.storage import DataStorage
+from hypebot.config import Config
+
+
+def _make_df(prices: list[float], start: datetime | None = None) -> pd.DataFrame:
+    start = start or datetime.utcnow() - timedelta(days=len(prices))
+    idx = [start + timedelta(days=i) for i in range(len(prices))]
+    return pd.DataFrame({
+        "open": prices,
+        "high": prices,
+        "low": prices,
+        "close": prices,
+        "volume": [1.0] * len(prices),
+    }, index=pd.to_datetime(idx, utc=True))
+
+
+def _to_ind_input(df: pd.DataFrame, symbol: str) -> pd.DataFrame:
+    t = df[["close"]].rename(columns={"close": "price"}).reset_index().rename(columns={"index": "timestamp"})
+    t["symbol"] = symbol
+    return t
+
+
+class TestRSIEMAHybridStrategy:
+    def setup_method(self):
+        self.config = Config.from_env()
+        storage = DataStorage(self.config.database)
+        # For unit tests, do not persist
+        self.pm = PositionManager(self.config.trading, storage, load_existing=False, starting_cash=1000.0, persist=False)
+        self.rsi = RSICalculator(period=14, oversold_threshold=30, overbought_threshold=70)
+        self.ema = EMACalculator(period=20)
+        self.strategy = RSIEMAHybridStrategy(
+            assets=["BTC-USD"],
+            interval="1d",
+            position_manager=self.pm,
+            rsi_calculator=self.rsi,
+            ema_calculator=self.ema,
+            rsi_trend_threshold=50.0,
+            oversold_threshold=30.0,
+        )
+
+    def test_no_signal_with_insufficient_history(self):
+        df = _make_df([100.0] * 10)  # less than EMA/RSI period
+        orders = asyncio.run(self.strategy.tick(datetime.utcnow(), {"BTC-USD": df}))
+        assert orders == []
+
+    def test_entry_when_rsi_above_50_and_price_above_ema(self, monkeypatch):
+        # Construct rising prices to push RSI > 50 and close > EMA
+        prices = [i for i in range(80, 120)]
+        df = _make_df(prices)
+        # Ensure enough cash to buy
+        self.pm.cash_balance = 1000.0
+        orders = asyncio.run(self.strategy.tick(datetime.utcnow(), {"BTC-USD": df}))
+        assert len(orders) in (0, 1)  # RSI depends on series; usually 1
+        if orders:
+            o = orders[0]
+            assert o.side == "BUY"
+            assert o.quantity > 0
+
+    def test_exit_when_rsi_drops_below_50(self):
+        # Simulate existing long position
+        # Directly set a simple position in manager
+        self.pm._positions["BTC-USD"] = type("P", (), {"side": "LONG", "size": 1.0})()
+        prices = [i for i in range(80, 120)] + [100.0] * 30  # plateau to potentially lower RSI
+        df = _make_df(prices)
+        orders = asyncio.run(self.strategy.tick(datetime.utcnow(), {"BTC-USD": df}))
+        # Might or might not trigger depending on series; check that any SELL does not exceed position size
+        for o in orders:
+            if o.side == "SELL":
+                assert o.quantity == 1.0
+
+    def test_exit_when_price_below_ema(self):
+        # Existing long
+        self.pm._positions["BTC-USD"] = type("P", (), {"side": "LONG", "size": 0.5})()
+        # Prices dip under EMA
+        prices = [100.0] * 30 + [90.0] * 10
+        df = _make_df(prices)
+        orders = asyncio.run(self.strategy.tick(datetime.utcnow(), {"BTC-USD": df}))
+        for o in orders:
+            if o.side == "SELL":
+                assert o.quantity == 0.5
+
+


### PR DESCRIPTION
… backtester

Implement strategy/hybrid_rsi_ema_strategy.py
Add indicators/ema.py and export via indicators/init.py 
Wire strategy in strategy/init.py and update strategy/runner.py 
Enhance backtesting/backtester.py with position tracking and CSV exports 
Update backtest.py to support new configs/runs
Add tests: test_ema_calculator.py, test_hybrid_rsi_ema_strategy.py, test_backtester_position_tracking.py, test_backtest_utility_position_export.py 
Refresh docs/specs: SPEC/spec.md, SPEC/strategies.md, SPEC/utilities.md